### PR TITLE
Update settings.json and pre-commit

### DIFF
--- a/.claude/hooks/auto-commit.sh
+++ b/.claude/hooks/auto-commit.sh
@@ -35,7 +35,7 @@ Modified $FILE_COUNT file(s):
 $FILE_LIST"
         
         # Make the commit
-        git commit -m "$COMMIT_MSG" > /dev/null 2>&1
+        git commit --no-verify -m "$COMMIT_MSG" > /dev/null 2>&1
         
         if [ $? -eq 0 ]; then
             echo "Successfully created auto-commit for $FILE_COUNT file(s)"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,6 @@
 {
   "hooks": {
-    "PostAssistantResponse": [
+    "Stop": [
       {
         "hooks": [
           {

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,5 +1,14 @@
 #!/bin/bash
+# --- START: Added check for auto-commit message ---
+# The path to the file containing the commit message is passed as the first argument.
+COMMIT_MSG_FILE=$1
 
+# If the commit message being created contains the auto-commit tag, exit immediately.
+# This allows the auto-commit to proceed without triggering the squash.
+if grep -q "\[auto-commit-hook\]" "$COMMIT_MSG_FILE"; then
+    exit 0
+fi
+# --- END: Added check ---
 # Pre-commit hook to squash [auto-commit-hook] commits
 
 # Check if there are any staged changes


### PR DESCRIPTION
I don't think there is a PostAssistantResponse hook

Change to Stop hook

```
    UserPromptSubmit: Triggers when a user submits a prompt, before Claude processes it.[1]

    PreToolUse: Runs before a tool (like file editing or a shell command) is used.[1][2]

    PostToolUse: Runs after a tool has been used successfully.[1][2][3]

    Notification: Executes when Claude Code sends a notification, for example when it needs user input.[1][2]

    Stop: Triggers when Claude Code finishes its entire response or task.[1][2][4]

    SubagentStop: Runs when a sub-agent's task is complete.[2]
```